### PR TITLE
Define Instance, Module, etc. inside Wasmer module

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Then, we can execute it in Ruby (!) with the `examples/simple.rb` file:
 require "wasmer"
 
 bytes = IO.read "simple.wasm", mode: "rb"
-instance = Instance.new bytes
+instance = Wasmer::Instance.new bytes
 puts instance.exports.sum 1, 2
 ```
 
@@ -85,7 +85,7 @@ require "wasmer"
 wasm_bytes = IO.read "my_program.wasm", mode: "rb"
 
 # Instantiates the Wasm module.
-instance = Instance.new wasm_bytes
+instance = Wasmer::Instance.new wasm_bytes
 
 # Call a function on it.
 result = instance.exports.sum 1, 2
@@ -109,7 +109,7 @@ See below for more information.
 ## The `Memory` class
 
 A WebAssembly instance has its own memory, represented by the `Memory`
-class. It is accessible by the `Instance.memory` getter.
+class. It is accessible by the `Wasmer::Instance.memory` getter.
 
 The `Memory` class offers methods to create views of the memory
 internal buffer, e.g. `uint8_view`, `int8_view`, `uint16_view`
@@ -159,7 +159,7 @@ require "wasmer"
 wasm_bytes = IO.read "my_program.wasm", mode: "rb"
 
 # Instantiates the Wasm module.
-instance = Instance.new wasm_bytes
+instance = Wasmer::Instance.new wasm_bytes
 
 # Call a function that returns a pointer to a string for instance.
 pointer = instance.exports.return_string

--- a/examples/memory.rb
+++ b/examples/memory.rb
@@ -4,7 +4,7 @@ require "wasmer"
 
 file = File.expand_path "memory.wasm", File.dirname(__FILE__)
 bytes = IO.read file, mode: "rb"
-instance = Instance.new bytes
+instance = Wasmer::Instance.new bytes
 pointer = instance.exports.return_hello
 
 memory = instance.memory.uint8_view pointer

--- a/examples/simple.rb
+++ b/examples/simple.rb
@@ -4,5 +4,5 @@ require "wasmer"
 
 file = File.expand_path "simple.wasm", File.dirname(__FILE__)
 bytes = IO.read file, mode: "rb"
-instance = Instance.new bytes
+instance = Wasmer::Instance.new bytes
 puts instance.exports.sum 1, 2

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -7,7 +7,7 @@ use rutie::{
     rubysys::{class, value::ValueType},
     types::{Argc, Value},
     util::str_to_cstring,
-    wrappable_struct, AnyException, AnyObject, Array, Class, Exception, Fixnum, Float, Object,
+    wrappable_struct, AnyException, AnyObject, Array, Module, Exception, Fixnum, Float, Object,
     RString, Symbol, VM,
 };
 use std::{mem, rc::Rc};
@@ -249,17 +249,19 @@ methods!(
             .ok_or_else(|| VM::raise_ex(AnyException::new("RuntimeError", Some("The WebAssembly module has no exported memory."))))
             .unwrap();
 
+        let wasmer_module = Module::from_existing("Wasmer");
+
         let mut ruby_instance: AnyObject =
-            Class::from_existing("Instance").wrap_data(instance, &*INSTANCE_WRAPPER);
+            wasmer_module.get_nested_class("Instance").wrap_data(instance, &*INSTANCE_WRAPPER);
 
         let ruby_exported_functions: RubyExportedFunctions =
-            Class::from_existing("ExportedFunctions")
+            wasmer_module.get_nested_class("ExportedFunctions")
                 .wrap_data(exported_functions, &*EXPORTED_FUNCTIONS_WRAPPER);
 
         ruby_instance.instance_variable_set("@exports", ruby_exported_functions);
 
         let ruby_memory: RubyMemory =
-            Class::from_existing("Memory").wrap_data(memory, &*MEMORY_WRAPPER);
+            wasmer_module.get_nested_class("Memory").wrap_data(memory, &*MEMORY_WRAPPER);
 
         ruby_instance.instance_variable_set("@memory", ruby_memory);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(warnings)]
 
-use rutie::{Class, Object};
+use rutie::{Class, Module, Object};
 
 pub mod instance;
 pub mod memory;
@@ -9,10 +9,12 @@ pub mod module;
 #[allow(non_snake_case)]
 #[no_mangle]
 pub extern "C" fn Init_wasmer() {
+    let mut wasmer_module = Module::from_existing("Wasmer");
+
     let instance_data_class = Class::from_existing("Object");
 
     // Declare the `Instance` Ruby class.
-    Class::new("Instance", Some(&instance_data_class)).define(|itself| {
+    wasmer_module.define_nested_class("Instance", Some(&instance_data_class)).define(|itself| {
         // Declare the `self.new` method.
         itself.def_self("new", instance::ruby_instance_new);
 
@@ -26,7 +28,7 @@ pub extern "C" fn Init_wasmer() {
     let exported_functions_data_class = Class::from_existing("Object");
 
     // Declare the `ExportedFunctions` Ruby class.
-    Class::new("ExportedFunctions", Some(&exported_functions_data_class)).define(|itself| {
+    wasmer_module.define_nested_class("ExportedFunctions", Some(&exported_functions_data_class)).define(|itself| {
         // Declare the `method_missing` method.
         itself.def(
             "method_missing",
@@ -37,7 +39,7 @@ pub extern "C" fn Init_wasmer() {
     let module_data_class = Class::from_existing("Object");
 
     // Declare the `Module` Ruby class.
-    Class::new("Module", Some(&module_data_class)).define(|itself| {
+    wasmer_module.define_nested_class("Module", Some(&module_data_class)).define(|itself| {
         // Declare the `self.validate` method.
         itself.def_self("validate", module::ruby_module_validate);
     });
@@ -45,7 +47,7 @@ pub extern "C" fn Init_wasmer() {
     let memory_data_class = Class::from_existing("Object");
 
     // Declare the `Memory` Ruby class.
-    Class::new("Memory", Some(&memory_data_class)).define(|itself| {
+    wasmer_module.define_nested_class("Memory", Some(&memory_data_class)).define(|itself| {
         // Declare the `view` method.
         itself.def("uint8_view", memory::ruby_memory_uint8array);
 
@@ -70,7 +72,7 @@ pub extern "C" fn Init_wasmer() {
             let uint8array_data_class = Class::from_existing("Object");
 
             // Declare the `MemoryView` Ruby class.
-            Class::new(stringify!($class_name), Some(&uint8array_data_class)).define(|itself| {
+            wasmer_module.define_nested_class(stringify!($class_name), Some(&uint8array_data_class)).define(|itself| {
                 // Declare the `bytes_per_element` getter method.
                 itself.def(
                     "bytes_per_element",

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -11,7 +11,7 @@ use crate::memory::view::{
     uint8array::{RubyMemoryView as RubyUint8Array, MEMORY_VIEW_WRAPPER as UINT8ARRAY_WRAPPER},
 };
 use lazy_static::lazy_static;
-use rutie::{class, methods, wrappable_struct, Class, Integer, Object};
+use rutie::{class, methods, wrappable_struct, Module, Integer, Object};
 use std::rc::Rc;
 use wasmer_runtime as runtime;
 
@@ -65,7 +65,8 @@ methods!(
             .unwrap_or(0);
         let memory_view = itself.get_data(&*MEMORY_WRAPPER).uint8_view(offset);
 
-        Class::from_existing("Uint8Array").wrap_data(memory_view, &*UINT8ARRAY_WRAPPER)
+        let wasmer_module = Module::from_existing("Wasmer");
+        wasmer_module.get_nested_class("Uint8Array").wrap_data(memory_view, &*UINT8ARRAY_WRAPPER)
     }
 
     // Glue code to call the `Memory.int8_view` method.
@@ -75,7 +76,8 @@ methods!(
             .unwrap_or(0);
         let memory_view = itself.get_data(&*MEMORY_WRAPPER).int8_view(offset);
 
-        Class::from_existing("Int8Array").wrap_data(memory_view, &*INT8ARRAY_WRAPPER)
+        let wasmer_module = Module::from_existing("Wasmer");
+        wasmer_module.get_nested_class("Int8Array").wrap_data(memory_view, &*INT8ARRAY_WRAPPER)
     }
 
     // Glue code to call the `Memory.uint16_view` method.
@@ -85,7 +87,8 @@ methods!(
             .unwrap_or(0);
         let memory_view = itself.get_data(&*MEMORY_WRAPPER).uint16_view(offset);
 
-        Class::from_existing("Uint16Array").wrap_data(memory_view, &*UINT16ARRAY_WRAPPER)
+        let wasmer_module = Module::from_existing("Wasmer");
+        wasmer_module.get_nested_class("Uint16Array").wrap_data(memory_view, &*UINT16ARRAY_WRAPPER)
     }
 
     // Glue code to call the `Memory.int16_view` method.
@@ -95,7 +98,8 @@ methods!(
             .unwrap_or(0);
         let memory_view = itself.get_data(&*MEMORY_WRAPPER).int16_view(offset);
 
-        Class::from_existing("Int16Array").wrap_data(memory_view, &*INT16ARRAY_WRAPPER)
+        let wasmer_module = Module::from_existing("Wasmer");
+        wasmer_module.get_nested_class("Int16Array").wrap_data(memory_view, &*INT16ARRAY_WRAPPER)
     }
 
     // Glue code to call the `Memory.uint32_view` method.
@@ -105,7 +109,8 @@ methods!(
             .unwrap_or(0);
         let memory_view = itself.get_data(&*MEMORY_WRAPPER).uint32_view(offset);
 
-        Class::from_existing("Uint32Array").wrap_data(memory_view, &*UINT32ARRAY_WRAPPER)
+        let wasmer_module = Module::from_existing("Wasmer");
+        wasmer_module.get_nested_class("Uint32Array").wrap_data(memory_view, &*UINT32ARRAY_WRAPPER)
     }
 
     // Glue code to call the `Memory.int32_view` method.
@@ -115,6 +120,7 @@ methods!(
             .unwrap_or(0);
         let memory_view = itself.get_data(&*MEMORY_WRAPPER).int32_view(offset);
 
-        Class::from_existing("Int32Array").wrap_data(memory_view, &*INT32ARRAY_WRAPPER)
+        let wasmer_module = Module::from_existing("Wasmer");
+        wasmer_module.get_nested_class("Int32Array").wrap_data(memory_view, &*INT32ARRAY_WRAPPER)
     }
 );

--- a/tests/instance_test.rb
+++ b/tests/instance_test.rb
@@ -10,12 +10,12 @@ class InstanceTest < Minitest::Test
   end
 
   def test_can_construct
-    assert Instance.new self.bytes
+    assert Wasmer::Instance.new self.bytes
   end
 
   def test_constructor_needs_bytes
     error = assert_raises(ArgumentError) {
-      Instance.new 123
+      Wasmer::Instance.new 123
     }
     assert_equal "WebAssembly module must be represented by Ruby bytes only.", error.message
   end
@@ -23,87 +23,87 @@ class InstanceTest < Minitest::Test
   def test_module_must_have_an_exported_memory
     error = assert_raises(RuntimeError) {
       bytes = IO.read File.expand_path("no_memory.wasm", File.dirname(__FILE__)), mode: "rb"
-      Instance.new bytes
+      Wasmer::Instance.new bytes
     }
     assert_equal "The WebAssembly module has no exported memory.", error.message
   end
 
   def test_invalid_module
     error = assert_raises(RuntimeError) {
-      Instance.new self.invalid_bytes
+      Wasmer::Instance.new self.invalid_bytes
     }
     assert_equal "Failed to instantiate the module:\n    compile error: Validation error \"Invalid type\"", error.message
   end
 
   def test_basic_sum
-    assert_equal 3, Instance.new(self.bytes).exports.sum(1, 2)
+    assert_equal 3, Wasmer::Instance.new(self.bytes).exports.sum(1, 2)
   end
 
   def test_call_unknown_function
     error = assert_raises(RuntimeError) {
-      Instance.new(self.bytes).exports.foo
+      Wasmer::Instance.new(self.bytes).exports.foo
     }
     assert_equal "Function `foo` does not exist.", error.message
   end
 
   def test_call_missing_argument
     error = assert_raises(ArgumentError) {
-      Instance.new(self.bytes).exports.sum 1
+      Wasmer::Instance.new(self.bytes).exports.sum 1
     }
     assert_equal "Missing 1 argument(s) when calling `sum`: Expect 2 argument(s), given 1.", error.message
   end
 
   def test_call_extra_argument
     error = assert_raises(ArgumentError) {
-      Instance.new(self.bytes).exports.sum 1, 2, 3
+      Wasmer::Instance.new(self.bytes).exports.sum 1, 2, 3
     }
     assert_equal "Given 1 extra argument(s) when calling `sum`: Expect 2 argument(s), given 3.", error.message
   end
 
   def test_call_cannot_convert_argument
     error = assert_raises(ArgumentError) {
-      Instance.new(self.bytes).exports.sum 1, "2"
+      Wasmer::Instance.new(self.bytes).exports.sum 1, "2"
     }
     assert_equal "Cannot convert argument #2 to a WebAssembly value. Only integers and floats are supported. Given `RString`.", error.message
   end
 
   def test_call_arity_0
-    assert_equal 42, Instance.new(self.bytes).exports.arity_0
+    assert_equal 42, Wasmer::Instance.new(self.bytes).exports.arity_0
   end
 
   def test_call_i32_i32
-    assert_equal 7, Instance.new(self.bytes).exports.i32_i32(7)
+    assert_equal 7, Wasmer::Instance.new(self.bytes).exports.i32_i32(7)
   end
 
   def test_call_i64_i64
-    assert_equal 7, Instance.new(self.bytes).exports.i64_i64(7)
+    assert_equal 7, Wasmer::Instance.new(self.bytes).exports.i64_i64(7)
   end
 
   def test_call_f32_f32
-    assert_equal 7.0, Instance.new(self.bytes).exports.f32_f32(7.0)
+    assert_equal 7.0, Wasmer::Instance.new(self.bytes).exports.f32_f32(7.0)
   end
 
   def test_call_f64_f64
-    assert_equal 7.0, Instance.new(self.bytes).exports.f64_f64(7.0)
+    assert_equal 7.0, Wasmer::Instance.new(self.bytes).exports.f64_f64(7.0)
   end
 
   def test_call_i32_i64_f32_f64_f64
-    assert_equal 1 + 2 + 3.4 + 5.6, Instance.new(self.bytes).exports.i32_i64_f32_f64_f64(1, 2, 3.4, 5.6).round(6)
+    assert_equal 1 + 2 + 3.4 + 5.6, Wasmer::Instance.new(self.bytes).exports.i32_i64_f32_f64_f64(1, 2, 3.4, 5.6).round(6)
   end
 
   def test_call_bool_casted_to_i32
-    assert_equal 1, Instance.new(self.bytes).exports.bool_casted_to_i32
+    assert_equal 1, Wasmer::Instance.new(self.bytes).exports.bool_casted_to_i32
   end
 
   def test_call_string
-    assert_equal 1048576, Instance.new(self.bytes).exports.string
+    assert_equal 1048576, Wasmer::Instance.new(self.bytes).exports.string
   end
 
   def test_exports
-    assert_instance_of ExportedFunctions, Instance.new(self.bytes).exports
+    assert_instance_of Wasmer::ExportedFunctions, Wasmer::Instance.new(self.bytes).exports
   end
 
   def test_memory
-    assert_instance_of Memory, Instance.new(self.bytes).memory
+    assert_instance_of Wasmer::Memory, Wasmer::Instance.new(self.bytes).memory
   end
 end

--- a/tests/memory_test.rb
+++ b/tests/memory_test.rb
@@ -6,37 +6,37 @@ class MemoryTest < Minitest::Test
   end
 
   def test_memory
-    assert_instance_of Memory, Instance.new(self.bytes).memory
+    assert_instance_of Wasmer::Memory, Wasmer::Instance.new(self.bytes).memory
   end
 
   def test_typedarrays
-    assert_instance_of Uint8Array, Instance.new(self.bytes).memory.uint8_view
-    assert_instance_of Int8Array, Instance.new(self.bytes).memory.int8_view
-    assert_instance_of Uint16Array, Instance.new(self.bytes).memory.uint16_view
-    assert_instance_of Int16Array, Instance.new(self.bytes).memory.int16_view
-    assert_instance_of Uint32Array, Instance.new(self.bytes).memory.uint32_view
-    assert_instance_of Int32Array, Instance.new(self.bytes).memory.int32_view
+    assert_instance_of Wasmer::Uint8Array, Wasmer::Instance.new(self.bytes).memory.uint8_view
+    assert_instance_of Wasmer::Int8Array, Wasmer::Instance.new(self.bytes).memory.int8_view
+    assert_instance_of Wasmer::Uint16Array, Wasmer::Instance.new(self.bytes).memory.uint16_view
+    assert_instance_of Wasmer::Int16Array, Wasmer::Instance.new(self.bytes).memory.int16_view
+    assert_instance_of Wasmer::Uint32Array, Wasmer::Instance.new(self.bytes).memory.uint32_view
+    assert_instance_of Wasmer::Int32Array, Wasmer::Instance.new(self.bytes).memory.int32_view
   end
 
   def test_bytes_per_element
-    assert_equal 1, Instance.new(self.bytes).memory.uint8_view.bytes_per_element
-    assert_equal 1, Instance.new(self.bytes).memory.int8_view.bytes_per_element
-    assert_equal 2, Instance.new(self.bytes).memory.uint16_view.bytes_per_element
-    assert_equal 2, Instance.new(self.bytes).memory.int16_view.bytes_per_element
-    assert_equal 4, Instance.new(self.bytes).memory.uint32_view.bytes_per_element
-    assert_equal 4, Instance.new(self.bytes).memory.int32_view.bytes_per_element
+    assert_equal 1, Wasmer::Instance.new(self.bytes).memory.uint8_view.bytes_per_element
+    assert_equal 1, Wasmer::Instance.new(self.bytes).memory.int8_view.bytes_per_element
+    assert_equal 2, Wasmer::Instance.new(self.bytes).memory.uint16_view.bytes_per_element
+    assert_equal 2, Wasmer::Instance.new(self.bytes).memory.int16_view.bytes_per_element
+    assert_equal 4, Wasmer::Instance.new(self.bytes).memory.uint32_view.bytes_per_element
+    assert_equal 4, Wasmer::Instance.new(self.bytes).memory.int32_view.bytes_per_element
   end
 
   def test_view_with_offset
-    assert_instance_of Uint8Array, Instance.new(self.bytes).memory.uint8_view(7)
+    assert_instance_of Wasmer::Uint8Array, Wasmer::Instance.new(self.bytes).memory.uint8_view(7)
   end
 
   def test_length
-    assert_equal 1114112, Instance.new(self.bytes).memory.uint8_view.length
+    assert_equal 1114112, Wasmer::Instance.new(self.bytes).memory.uint8_view.length
   end
 
   def test_get
-    memory = Instance.new(self.bytes).memory.uint8_view
+    memory = Wasmer::Instance.new(self.bytes).memory.uint8_view
     index = 0
     value = 42
     memory[index] = value
@@ -46,54 +46,54 @@ class MemoryTest < Minitest::Test
 
   def test_get_invalid_index_type
     error = assert_raises(TypeError) {
-      Instance.new(self.bytes).memory.uint8_view["-1"]
+      Wasmer::Instance.new(self.bytes).memory.uint8_view["-1"]
     }
     assert_equal "Error converting to Integer", error.message
   end
 
   def test_get_out_of_bound_negative
     error = assert_raises(ArgumentError) {
-      Instance.new(self.bytes).memory.uint8_view[-1]
+      Wasmer::Instance.new(self.bytes).memory.uint8_view[-1]
     }
     assert_equal "Out of bound: Index cannot be negative.", error.message
   end
 
   def test_get_out_of_bound_too_large
     error = assert_raises(ArgumentError) {
-      memory = Instance.new(self.bytes).memory.uint8_view
+      memory = Wasmer::Instance.new(self.bytes).memory.uint8_view
       length = memory.length
 
-      Instance.new(self.bytes).memory.uint8_view[length + 1]
+      Wasmer::Instance.new(self.bytes).memory.uint8_view[length + 1]
     }
     assert_equal "Out of bound: Maximum index 1114113 is larger than the memory size 1114112.", error.message
   end
 
   def test_set_invalid_index_type
     error = assert_raises(TypeError) {
-      Instance.new(self.bytes).memory.uint8_view["-1"] = 1
+      Wasmer::Instance.new(self.bytes).memory.uint8_view["-1"] = 1
     }
     assert_equal "Error converting to Integer", error.message
   end
 
   def test_set_out_of_bound_negative
     error = assert_raises(ArgumentError) {
-      Instance.new(self.bytes).memory.uint8_view[-1] = 1
+      Wasmer::Instance.new(self.bytes).memory.uint8_view[-1] = 1
     }
     assert_equal "Out of bound: Index cannot be negative.", error.message
   end
 
   def test_set_out_of_bound_too_large
     error = assert_raises(ArgumentError) {
-      memory = Instance.new(self.bytes).memory.uint8_view
+      memory = Wasmer::Instance.new(self.bytes).memory.uint8_view
       length = memory.length
 
-      Instance.new(self.bytes).memory.uint8_view[length + 1] = 1
+      Wasmer::Instance.new(self.bytes).memory.uint8_view[length + 1] = 1
     }
     assert_equal "Out of bound: Maximum index 1114113 is larger than the memory size 1114112.", error.message
   end
 
   def test_hello_world
-    instance = Instance.new(self.bytes)
+    instance = Wasmer::Instance.new(self.bytes)
     pointer = instance.exports.string
     memory = instance.memory.uint8_view pointer
     nth = 0
@@ -114,7 +114,7 @@ class MemoryTest < Minitest::Test
   end
 
   def test_views_share_the_same_buffer
-    instance = Instance.new self.bytes
+    instance = Wasmer::Instance.new self.bytes
     int8 = instance.memory.int8_view
     int16 = instance.memory.int16_view
     int32 = instance.memory.int32_view

--- a/tests/module_test.rb
+++ b/tests/module_test.rb
@@ -10,14 +10,14 @@ class ModuleTest < Minitest::Test
   end
 
   def test_validate
-    assert Module.validate self.valid_bytes
+    assert Wasmer::Module.validate self.valid_bytes
   end
 
   def test_validate_invalid_bytes
-    assert_equal false, Module.validate(self.invalid_bytes)
+    assert_equal false, Wasmer::Module.validate(self.invalid_bytes)
   end
 
   def test_validate_invalid_type
-    assert_equal false, Module.validate(42)
+    assert_equal false, Wasmer::Module.validate(42)
   end
 end


### PR DESCRIPTION
PHP has a namespace feature but Ruby does not. In Ruby, we define classes inside of module instead.

```ruby
module Wasmer
  class Instance
    def initialize
      # ...
    end
  end
end

instance = Wasmer::Instance.new()
```

I changed to define classes inside the `Wasmer` module to prevent the global namespace from being polluted with generic name such as `Module`.
