### PR TITLE
Handled Ruby's exceptions correctly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use rutie::{Class, Module, Object};
 pub mod instance;
 pub mod memory;
 pub mod module;
+pub mod util;
 
 #[allow(non_snake_case)]
 #[no_mangle]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,12 @@
+use rutie::{AnyException, VM};
+
+pub fn unwrap_or_raise<T, F: FnOnce() ->Result<T, AnyException>>(f: F) -> T {
+    let result = f();
+    match result {
+        Ok(x) => x,
+        Err(e) => {
+            VM::raise_ex(e);
+            unreachable!()
+        }
+    }
+}


### PR DESCRIPTION
`VM::raise_ex` is a dangerous function and should be used carefully

Rust has a drop function to release memory, etc. This internal implementation is a feature called unwind. Ruby, on the other hand, uses longjump as an exception. Rust's drop function doesn't work properly when using two functions together. If you throw a Ruby exception in the middle of a Rust program, the following program will not be executed, so a memory leak may occur.

I introduced the `unwrap_or_raise` function and corrected so that drop will always be executed before a Ruby exception occurs.