### PR TITLE
Use Thermite to build extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /Gemfile.lock
 /pkg
 /target
+mkmf.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "ruby-ext-wasm"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rutie 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ wasmer-runtime = "0.4.0"
 wasmer-runtime-core = "0.4.0"
 rutie = "0.5.4"
 lazy_static = "1.3.0"
+
+[package.metadata.thermite]
+github_releases = true

--- a/Rakefile
+++ b/Rakefile
@@ -1,21 +1,14 @@
 require "rbconfig"
 require "bundler/gem_tasks"
 require "rake/testtask"
+require "thermite/tasks"
 
-desc 'Build the Rust extension'
-task :build_lib do
-  sh 'cargo build --release'
-end
-
-desc 'Install the bundle'
-task :bundle_install do
-  sh 'bundle install'
-end
-
-Rake::TestTask.new(test: [:bundle_install, :build_lib]) do |t|
+Rake::TestTask.new(test: ["thermite:build", "thermite:test"]) do |t|
   t.libs << "tests"
   t.libs << "lib"
   t.test_files = FileList["tests/**/*_test.rb"]
 end
+
+Thermite::Tasks.new
 
 task :default => :test

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -1,0 +1,5 @@
+require "thermite/tasks"
+
+project_dir = File.dirname(File.dirname(__FILE__))
+Thermite::Tasks.new(cargo_project_path: project_dir, ruby_project_path: project_dir)
+task default: %w(thermite:build)

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 # Compile and install the Ruby extension.
 build:
-	rake build_lib
+	rake thermite:build
 
 # Run the tests.
 test:

--- a/wasmer.gemspec
+++ b/wasmer.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/wasmerio/ruby-ext-wasm"
   spec.license       = "BSD-3-Clause"
 
-  spec.extensions    = %w(Rakefile)
+  spec.extensions    = %w(ext/Rakefile)
 
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(examples|tests)/}) }
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w(lib)
 
   spec.add_dependency "rutie", "~> 0.0.3"
+  spec.add_runtime_dependency "thermite", "~> 0"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
Hello maintainers!

I am very interested in trying out this gem for some projects. One major obstacle to this is that installing the gem currently requires a working installation of `cargo`. This means I can't use this gem on a remote server where I may not be able to install `cargo`.

In this PR, I propose to add [Thermite](https://github.com/malept/thermite) to manage building, compiling, and installing the gem's extension code.

### Info about Thermite

>Thermite is a Rake-based helper for building and distributing Rust-based Ruby extensions.

Thermite's biggest advantage is that it provides a way to automatically check for and download precompiled libraries when a user tries to install the gem. When a user runs `gem install wasmer`, Thermite will check for a precompiled library on GitHub Releases that matches the version of `wasmer` requested, the user's platform, and the user's architecture. If a precompiled library exists, that is downloaded and unpacked; if one does not exist, then regular `cargo build --release` is used.

For an example of a Rust-based Ruby extension using Thermite, check out [rusty_blank](https://github.com/malept/rusty_blank).

### Need a CI platform

The advantage of Thermite is that it can download precompiled libraries, but that means this project will need some way to generate those libraries. I do not see any common CI config files in the project, so I think a first step would be to choose a CI provider.

I would personally recommend [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) because Pipelines gives access to Linux, macOS, and Windows build nodes, all in one platform. This would mean that the project could run tests on all 3 platforms and also compile libraries on all 3 platforms.

Maybe this PR should wait until a CI platform is chosen. I can revisit this PR to update the CI scripts to add the necessary steps to publish releases after.