### PR TITLE
Implement `respond_to_missing?`

### DIFF
--- a/src/instance.rs
+++ b/src/instance.rs
@@ -170,7 +170,7 @@ class!(RubyExportedFunctions);
 
 #[rustfmt::skip]
 methods!(
-    RubyInstance,
+    RubyExportedFunctions,
     itself,
 
     fn ruby_exported_functions_method_exists(symbol: Symbol, _include_private: Boolean) -> Boolean {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -8,8 +8,8 @@ use rutie::{
     rubysys::{class, value::ValueType},
     types::{Argc, Value},
     util::str_to_cstring,
-    wrappable_struct, AnyException, AnyObject, Array, Exception, Fixnum, Float, Module, NilClass,
-    Object, RString, Symbol,
+    wrappable_struct, AnyException, AnyObject, Array, Boolean, Exception, Fixnum, Float, Module,
+    NilClass, Object, RString, Symbol,
 };
 use std::{mem, rc::Rc};
 use wasmer_runtime::{self as runtime, imports, Export};
@@ -25,6 +25,10 @@ impl ExportedFunctions {
     /// Create a new instance of the `ExportedFunctions` Ruby class.
     pub fn new(instance: Rc<runtime::Instance>) -> Self {
         Self { instance }
+    }
+
+    pub fn respond_to_missing(&self, method_name: &str) -> bool {
+        self.instance.dyn_func(method_name).is_ok()
     }
 
     /// Call an exported function on the given WebAssembly instance.
@@ -163,6 +167,20 @@ wrappable_struct!(
 );
 
 class!(RubyExportedFunctions);
+
+#[rustfmt::skip]
+methods!(
+    RubyInstance,
+    itself,
+
+    fn ruby_exported_functions_method_exists(symbol: Symbol, _include_private: Boolean) -> Boolean {
+        unwrap_or_raise(|| {
+            let symbol = symbol?;
+            let instance = itself.get_data(&*EXPORTED_FUNCTIONS_WRAPPER);
+            Ok(Boolean::new(instance.respond_to_missing(symbol.to_str())))
+        })
+    }
+);
 
 /// Glue code to call the `ExportedFunctions.method_missing` method.
 pub extern "C" fn ruby_exported_functions_method_missing(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,10 @@ pub extern "C" fn Init_wasmer() {
     wasmer_module
         .define_nested_class("ExportedFunctions", Some(&exported_functions_data_class))
         .define(|itself| {
-            // Declare the `method_missing` method.
+            itself.def(
+                "respond_to_missing?",
+                instance::ruby_exported_functions_method_exists,
+            );
             itself.def(
                 "method_missing",
                 instance::ruby_exported_functions_method_missing,

--- a/tests/instance_test.rb
+++ b/tests/instance_test.rb
@@ -36,12 +36,16 @@ class InstanceTest < Minitest::Test
   end
 
   def test_basic_sum
-    assert_equal 3, Wasmer::Instance.new(self.bytes).exports.sum(1, 2)
+    exports = Wasmer::Instance.new(self.bytes).exports
+    assert exports.respond_to?(:sum)
+    assert_equal 3, exports.sum(1, 2)
   end
 
   def test_call_unknown_function
+    exports = Wasmer::Instance.new(self.bytes).exports
+    assert !exports.respond_to?(:foo)
     error = assert_raises(RuntimeError) {
-      Wasmer::Instance.new(self.bytes).exports.foo
+      exports.foo
     }
     assert_equal "Function `foo` does not exist.", error.message
   end


### PR DESCRIPTION
Ruby uses the `respond_to?` method to check if a certain method exists. If `method_missing` is implemented, `respond_to_missing?` should also be implemented.