### PR TITLE
Enhance `Wasmer::XxxArray`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,8 @@ pub extern "C" fn Init_wasmer() {
 
                     // Declare the `each` method.
                     itself.def("each", memory::view::$mod_name::ruby_memory_view_each);
-                });
+                })
+                .include("Enumerable");
         };
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,9 @@ pub extern "C" fn Init_wasmer() {
 
                     // Declare the `[]` (get) method.
                     itself.def("[]", memory::view::$mod_name::ruby_memory_view_get);
+
+                    // Declare the `each` method.
+                    itself.def("each", memory::view::$mod_name::ruby_memory_view_each);
                 });
         };
     }

--- a/src/memory/view.rs
+++ b/src/memory/view.rs
@@ -75,11 +75,9 @@ macro_rules! memory_view {
                 pub fn each(&self) {
                     let view = self.memory.view::<$wasm_type>();
 
-                    let mut offset = self.offset;
-                    while offset < view.len() {
-                        let value = view[offset].get();
-                        VM::yield_object(Integer::from(value as i64));
-                        offset += 1;
+                    for nth in self.offset..view.len() {
+                        let value = view[nth].get() as i64;
+                        VM::yield_object(Integer::from(value));
                     }
                 }
             }

--- a/tests/memory_test.rb
+++ b/tests/memory_test.rb
@@ -99,17 +99,13 @@ class MemoryTest < Minitest::Test
     nth = 0
     string = ""
 
-    while true
-      char = memory[nth]
-
-      if 0 == char
-        break
-      end
-
-      string += char.chr
+    memory.each do |char|
+      break if 0 == char
+      string << char.chr
       nth += 1
     end
 
+    assert_equal 13, nth
     assert_equal "Hello, World!", string
   end
 

--- a/tests/memory_test.rb
+++ b/tests/memory_test.rb
@@ -109,6 +109,18 @@ class MemoryTest < Minitest::Test
     assert_equal "Hello, World!", string
   end
 
+  def test_enumerable
+    instance = Wasmer::Instance.new self.bytes
+    memory = instance.memory.int16_view
+    memory[0] = 1
+    memory[1] = 10
+    memory[2] = 100
+    memory[3] = 1000
+    memory[5] = 2
+    sum = memory.take_while{|x| x > 0}.inject(0, &:+)
+    assert_equal 1111, sum
+  end
+
   def test_views_share_the_same_buffer
     instance = Wasmer::Instance.new self.bytes
     int8 = instance.memory.int8_view


### PR DESCRIPTION
ref: #14
Now `Wasmer::XxxArray` has `each` method and include `Enumerable` module.

> The Enumerable mixin provides collection classes with several traversal and searching methods, and with the ability to sort. The class must provide a method each, which yields successive members of the collection.
https://docs.ruby-lang.org/en/2.6.0/Enumerable.html
