### PR TITLE
Remove Unused Import

### DIFF
--- a/crates/wasmer/src/prelude.rs
+++ b/crates/wasmer/src/prelude.rs
@@ -1,3 +1,3 @@
 pub use crate::error::RubyResult;
 pub use lazy_static::lazy_static;
-pub use rutie_derive::{rubyclass, rubyfunction, rubymethods, ClassInfo, UpcastRubyClass};
+pub use rutie_derive::{rubyclass, rubyfunction, rubymethods, UpcastRubyClass};


### PR DESCRIPTION
Starting around Rust 1.75 (I think) compiling wasmer started giving this error:

      Compiling wasmer v1.0.0 (/Users/{user}/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/wasmer-1.0.0/crates/wasmer)
    error: unused import: `ClassInfo`
    --> crates/wasmer/src/prelude.rs:3:62
      |
    3 | pub use rutie_derive::{rubyclass, rubyfunction, rubymethods, ClassInfo, UpcastRubyClass};
      |                                                              ^^^^^^^^^
      |

This seems to just be an unused struct. Removing it makes it compile and everything still seems to work when I use the lib (test suite fails but it does under older versions of Rust as well so I don't think that is related).

This will fix #76.